### PR TITLE
feat (cleaners & schedules): add crud operations api

### DIFF
--- a/src/components/cleaners/controller.ts
+++ b/src/components/cleaners/controller.ts
@@ -1,0 +1,84 @@
+import type { Request, Response } from "express";
+import * as service from "./service";
+import { normalizeError } from "@/utils/normalize-error";
+import { sendErrorResponse } from "@/common/responses/error";
+import { sendSuccessResponse } from "@/common/responses/success";
+import { CustomError } from "@/common/custom/error";
+
+export const getAllCleaners = async (req: Request, res: Response) => {
+  const cleaners = await service.getAllCleaners();
+
+  res.status(200).json(cleaners);
+};
+
+export const getCleaner = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const parsedId = Number(id);
+
+    if (isNaN(parsedId)) {
+      throw new CustomError("Invalid Cleaner ID format", 400);
+    }
+
+    const cleaner = await service.getCleaner(parsedId);
+
+    return sendSuccessResponse({
+      res,
+      data: cleaner,
+    });
+  } catch (error) {
+    const { message, statusCode } = normalizeError(error);
+
+    return sendErrorResponse({ res, message, statusCode });
+  }
+};
+
+export const createCleaner = async (req: Request, res: Response) => {
+  const { userId, experience, location } = req.body;
+
+  if (!userId || !location) {
+    res.status(400).json({ message: "Missing required fields" });
+    return;
+  }
+
+  const cleaner = await service.createCleaner({
+    userId,
+    location,
+    experience,
+  });
+
+  res.status(201).json(cleaner);
+};
+
+export const updateCleaner = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const parsedId = Number(id);
+  const { location, experience } = req.body;
+
+  if (!id) {
+    res.status(400).json({ message: "Missing required fields" });
+    return;
+  }
+
+  const cleaner = await service.updateCleaner({
+    id: parsedId,
+    location,
+    experience,
+  });
+
+  res.status(200).json(cleaner);
+};
+
+export const deleteCleaner = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const parsedId = Number(id);
+
+  if (!id) {
+    res.status(400).json({ message: "Missing required field" });
+    return;
+  }
+
+  const cleaner = await service.deleteCleaner(parsedId);
+
+  res.status(200).json(cleaner);
+};

--- a/src/components/cleaners/network.ts
+++ b/src/components/cleaners/network.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import * as controller from "./controller";
+import { createCleanerSchema, updateCleanerSchema } from "./validation";
+import { validate } from "@/middlewares/zod-validation";
+
+export const router = Router();
+
+router.get("/", controller.getAllCleaners);
+router.get("/:id", controller.getCleaner);
+router.post("/", validate(createCleanerSchema), controller.createCleaner);
+router.put("/:id", validate(updateCleanerSchema), controller.updateCleaner);
+router.delete("/:id", controller.deleteCleaner);

--- a/src/components/cleaners/service.ts
+++ b/src/components/cleaners/service.ts
@@ -1,0 +1,62 @@
+import prisma from "@/database/client";
+import { CustomError } from "@/common/custom/error";
+
+export type Cleaner = {
+  id?: number;
+  userId?: any;
+  location: string;
+  experience?: string;
+};
+
+export const getCleaner = async (id: number) => {
+  const cleaner = await prisma.cleaner.findUnique({
+    where: { id },
+    include: {
+      user: true,
+    }
+  });
+
+  if (!cleaner) {
+    throw new CustomError("Cleaner not found", 404);
+  }
+
+  return cleaner;
+};
+
+export const getAllCleaners = async () => {
+  const cleaners = await prisma.cleaner.findMany({
+    include: {
+      user: true,
+    },
+  });
+  return cleaners;
+};
+
+export const createCleaner = async (cleaner: Cleaner) => {
+  const { userId, location, experience } = cleaner;
+
+  const cleaners = await prisma.cleaner.create({
+    data: { userId, location, experience },
+  });
+
+  return cleaners;
+};
+
+export const updateCleaner = async (cleaner: Cleaner) => {
+  const { id, location, experience } = cleaner;
+
+  const cleaners = await prisma.cleaner.update({
+    where: { id },
+    data: { location, experience },
+  });
+
+  return cleaners;
+};
+
+export const deleteCleaner = async (id: number) => {
+  const cleaners = await prisma.cleaner.delete({
+    where: { id },
+  });
+
+  return cleaners;
+};

--- a/src/components/cleaners/validation.ts
+++ b/src/components/cleaners/validation.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createCleanerSchema = z.object({
+  userId: z.number().min(1, "User ID is required"),
+  location: z.string().min(1, "Location is required"),
+});
+
+export const updateCleanerSchema = z.object({
+  location: z.string().min(1, "Location is required"),
+  experience: z.string(),
+});

--- a/src/components/cleaningschedules/controller.ts
+++ b/src/components/cleaningschedules/controller.ts
@@ -1,0 +1,123 @@
+import type { Request, Response } from "express";
+import * as service from "./service";
+import { normalizeError } from "@/utils/normalize-error";
+import { sendErrorResponse } from "@/common/responses/error";
+import { sendSuccessResponse } from "@/common/responses/success";
+import { CustomError } from "@/common/custom/error";
+
+export const getCleaningSchedule = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const parsedId = Number(id);
+
+    if (isNaN(parsedId)) {
+      throw new CustomError("Invalid Schedule ID format", 400);
+    }
+
+    const schedule = await service.getCleaningSchedule(parsedId);
+
+    return sendSuccessResponse({
+      res,
+      data: schedule,
+    });
+  } catch (error) {
+    const { message, statusCode } = normalizeError(error);
+
+    return sendErrorResponse({ res, message, statusCode });
+  }
+};
+
+export const getCleaningScheduleByCleaner = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const parsedId = Number(id);
+
+    if (isNaN(parsedId)) {
+      throw new CustomError("Invalid Cleaner ID format", 400);
+    }
+
+    const schedule = await service.getCleaningScheduleByCleaner(parsedId);
+
+    return sendSuccessResponse({
+      res,
+      data: schedule,
+    });
+  } catch (error) {
+    const { message, statusCode } = normalizeError(error);
+
+    return sendErrorResponse({ res, message, statusCode });
+  }
+};
+
+export const getCleaningScheduleByProperty = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const parsedId = Number(id);
+
+    if (isNaN(parsedId)) {
+      throw new CustomError("Invalid Property ID format", 400);
+    }
+
+    const schedule = await service.getCleaningScheduleByProperty(parsedId);
+
+    return sendSuccessResponse({
+      res,
+      data: schedule,
+    });
+  } catch (error) {
+    const { message, statusCode } = normalizeError(error);
+
+    return sendErrorResponse({ res, message, statusCode });
+  }
+};
+
+export const createCleaningSchedule = async (req: Request, res: Response) => {
+  const { propertyId, cleanerId, startTime, endTime } = req.body;
+
+  if (!propertyId || !cleanerId || !startTime || !endTime) {
+    res.status(400).json({ message: "Missing required fields" });
+    return;
+  }
+
+  const schedule = await service.createCleaningSchedule({
+    propertyId,
+    cleanerId,
+    startTime,
+    endTime,
+  });
+
+  res.status(201).json(schedule);
+};
+
+export const updateCleaningSchedule = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const parsedId = Number(id);
+  const { startTime, endTime } = req.body;
+
+  if (!id) {
+    res.status(400).json({ message: "Missing required fields" });
+    return;
+  }
+
+  const schedule = await service.updateCleaningSchedule({
+    id: parsedId,
+    startTime,
+    endTime,
+  });
+
+  res.status(200).json(schedule);
+};
+
+export const deleteCleaningSchedule = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const parsedId = Number(id);
+
+  if (!id) {
+    res.status(400).json({ message: "Missing required field" });
+    return;
+  }
+
+  const schedule = await service.deleteCleaningSchedule(parsedId);
+
+  res.status(200).json(schedule);
+};

--- a/src/components/cleaningschedules/network.ts
+++ b/src/components/cleaningschedules/network.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import * as controller from "./controller";
+import { createCleaningScheduleSchema, updateCleaningScheduleSchema } from "./validation";
+import { validate } from "@/middlewares/zod-validation";
+
+export const router = Router();
+
+router.get("/:id", controller.getCleaningSchedule);
+router.get("/cleaner/:id", controller.getCleaningScheduleByCleaner);
+router.get("/property/:id", controller.getCleaningScheduleByProperty);
+router.post("/", validate(createCleaningScheduleSchema), controller.createCleaningSchedule);
+router.put("/:id", validate(updateCleaningScheduleSchema), controller.updateCleaningSchedule);
+router.delete("/:id", controller.deleteCleaningSchedule);

--- a/src/components/cleaningschedules/service.ts
+++ b/src/components/cleaningschedules/service.ts
@@ -1,0 +1,85 @@
+import prisma from "@/database/client";
+import { CustomError } from "@/common/custom/error";
+
+export type CleaningSchedule = {
+  id?: number;
+  propertyId?: any;
+  cleanerId?: any;
+  startTime: string;
+  endTime: string;
+}
+
+export const getCleaningSchedule = async (id: number) => {
+  const schedule = await prisma.cleaningSchedule.findUnique({
+    where: { id },
+    include: {
+      cleaner: true,
+      property: true,
+    }
+  });
+
+  if (!schedule) {
+    throw new CustomError("Schedule not found", 404);
+  }
+
+  return schedule;
+};
+
+export const getCleaningScheduleByProperty = async (propertyId: number) => {
+  const schedule = await prisma.cleaningSchedule.findMany({
+    where: { propertyId },
+    include: {
+      cleaner: true,
+      property: true,
+    },
+    orderBy: {
+      startTime: "asc",
+    },
+  });
+
+  return schedule;
+};
+
+export const getCleaningScheduleByCleaner = async (cleanerId: number) => {
+  const schedule = await prisma.cleaningSchedule.findMany({
+    where: { cleanerId },
+    include: {
+      cleaner: true,
+      property: true,
+    },
+    orderBy: {
+      startTime: "asc",
+    },
+  });
+
+  return schedule;
+};
+
+export const createCleaningSchedule = async (schedule: CleaningSchedule) => {
+  const { propertyId, cleanerId, startTime, endTime } = schedule;
+
+  const schedules = await prisma.cleaningSchedule.create({
+    data: { propertyId, cleanerId, startTime, endTime },
+  });
+
+  return schedules;
+};
+
+export const updateCleaningSchedule = async (schedule: CleaningSchedule) => {
+  const { id, startTime, endTime } = schedule;
+
+  const schedules = await prisma.cleaningSchedule.update({
+    where: { id },
+    data: { startTime, endTime },
+  });
+
+  return schedules;
+};
+
+export const deleteCleaningSchedule = async (id: number) => {
+  const schedules = await prisma.cleaningSchedule.delete({
+    where: { id },
+  });
+
+  return schedules;
+};

--- a/src/components/cleaningschedules/validation.ts
+++ b/src/components/cleaningschedules/validation.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const createCleaningScheduleSchema = z.object({
+  propertyId: z.number().min(1, "Property ID is required"),
+  cleanerId: z.number().min(1, "Cleaner ID is required"),
+  startTime: z.string().min(1, "Start time is required"),
+  endTime: z.string().min(1, "End time is required"),
+});
+
+export const updateCleaningScheduleSchema = z.object({
+  startTime: z.string().min(1, "Start time is required"),
+  endTime: z.string().min(1, "End time is required"),
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,12 +1,18 @@
 import { Application, Router } from "express";
 import { router as PropertiesRouter } from "@/components/properties/network";
+import { router as CleanersRouter } from "@/components/cleaners/network";
+import { router as CleaningSchedulesRouter } from "@/components/cleaningschedules/network";
 import { router as AuthRouter } from "@/components/auth/network";
 import { notFound } from "@/middlewares/not-found";
 import { errorHandler } from "@/middlewares/error-handler";
 import { auth } from "@/middlewares/auth";
 
 type Route = [string, Router];
-const privateRoutes: Route[] = [["properties", PropertiesRouter]];
+const privateRoutes: Route[] = [
+  ["properties", PropertiesRouter],
+  ["cleaners", CleanersRouter],
+  ["schedules", CleaningSchedulesRouter],
+];
 
 const publicRoutes: Route[] = [["auth", AuthRouter]];
 


### PR DESCRIPTION
# Cleaner and Cleaning Schedules API Implementation 

## Description

Added the following CRUD API operations:
- read clenaers api
- update cleaners api
- delete cleaners api
- update schedule api
- delete schedule api
- get schedule by property api
- get schedule by cleaner api
- get schedule by id api

## Type of Changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🛠️ Code refactor or improvement
- [ ] 🧪 Test enhancement
- [ ] 📖 Documentation update

## Checklist

- [x] Code compiles and runs correctly
- [x] Linting and formatting rules have been followed (`eslint`, `prettier`, etc.)
- [ ] Corresponding tests have been added and/or updated
- [ ] Documentation has been updated (if applicable)
- [ ] The PR title is clear and uses proper formatting
- [x] Commits are clean, with descriptive messages